### PR TITLE
Bugfix/86byfxxa8/fix empty cell in techspecs

### DIFF
--- a/src/components/TechSpecsSection/TechSpecs.tsx
+++ b/src/components/TechSpecsSection/TechSpecs.tsx
@@ -44,7 +44,9 @@ export const TechSpecs: React.FC<TechSpecsProps> = ({ product }) => {
   };
 
   const rows = Object.entries(productSpecs).reduce((accum, [key, value]) => {
-    accum.push(createRow(key, value));
+    if (value) {
+      accum.push(createRow(key, value));
+    }
 
     return accum;
   }, [] as TableRow[]);

--- a/src/components/TechSpecsSection/TechSpecs.tsx
+++ b/src/components/TechSpecsSection/TechSpecs.tsx
@@ -14,7 +14,7 @@ interface TechSpecsProps {
   product: ProductExpanded;
 }
 
-interface TableRow {
+interface Row {
   name: string;
   stringValue: string;
 }
@@ -31,7 +31,7 @@ export const TechSpecs: React.FC<TechSpecsProps> = ({ product }) => {
     cell: product.cell,
   };
 
-  const createRow = (name: string, value: string | string[]): TableRow => {
+  const createRow = (name: string, value: string | string[]): Row => {
     let stringValue = '';
 
     if (Array.isArray(value)) {
@@ -49,7 +49,7 @@ export const TechSpecs: React.FC<TechSpecsProps> = ({ product }) => {
     }
 
     return accum;
-  }, [] as TableRow[]);
+  }, [] as Row[]);
 
   return (
     <Stack sx={{ flex: 1 }} spacing={4}>


### PR DESCRIPTION
## DESCRIPTION

1. If value in `TechSpecs` cell is `false`, whole row will not render.